### PR TITLE
Fixes header pass through issues

### DIFF
--- a/src/ikspoz.cli/Program.cs
+++ b/src/ikspoz.cli/Program.cs
@@ -525,7 +525,10 @@ namespace Ikspoz.Cli
 
                     foreach (var requestHeaderKey in request.Headers.AllKeys)
                     {
-                        tunneledRequest.Headers.Add(requestHeaderKey, request.Headers.GetValues(requestHeaderKey)!);
+                        if (!requestHeaderKey.Equals("Host", StringComparison.OrdinalIgnoreCase))
+                        {
+                            tunneledRequest.Headers.Add(requestHeaderKey, request.Headers.GetValues(requestHeaderKey)!);
+                        }
                     }
 
                     HttpResponseMessage tunneledResponse;


### PR DESCRIPTION
Some HTTP headers were not being tunneled (either at all or correctly) which was blocking several scenarios related. 

Fixes #44.